### PR TITLE
update to lodash v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "lodash": "^3.7.0"
+    "lodash": "^4.15.0"
   },
   "devDependencies": {
     "browserify": "^4.1.5",

--- a/src/hashwords.coffee
+++ b/src/hashwords.coffee
@@ -1,10 +1,10 @@
 md5 = require('./md5').md5
 adjectives = require('./adjectives')
 nouns = require('./nouns')
-_defaults = require('lodash/object/defaults')
-_isArray = require('lodash/lang/isArray')
-_isNumber = require('lodash/lang/isNumber')
-_inRange = require('lodash/number/inRange')
+_defaults = require('lodash/defaults')
+_isArray = require('lodash/isArray')
+_isNumber = require('lodash/isNumber')
+_inRange = require('lodash/inRange')
 
 
 upperFirst = (str) ->


### PR DESCRIPTION
I noticed in one of my projects I was having to load an older version of lodash for hashwords, so I updated it. I did not commit the changes resulting from running `gulp`, but I did verify that the test works.
